### PR TITLE
Update boto3 dependency to 1.4.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     package_dir={'ish': 'ish'},
     packages=find_packages(),
     install_requires=[
-        'boto3==1.1.3',
+        'boto3==1.4.3',
         'jmespath==0.9.0'
     ]
 )


### PR DESCRIPTION
I was facing the following error while trying to use `ish` on my machine:

```
...
...
  File "/usr/local/lib/python3.6/site-packages/botocore-1.2.11-py3.6.egg/botocore/vendored/requests/sessions.py", line 573, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/botocore-1.2.11-py3.6.egg/botocore/vendored/requests/adapters.py", line 370, in send
    timeout=timeout
  File "/usr/local/lib/python3.6/site-packages/botocore-1.2.11-py3.6.egg/botocore/vendored/requests/packages/urllib3/connectionpool.py", line 544, in urlopen
    body=body, headers=headers)
  File "/usr/local/lib/python3.6/site-packages/botocore-1.2.11-py3.6.egg/botocore/vendored/requests/packages/urllib3/connectionpool.py", line 349, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/lib/python3.6/http/client.py", line 1239, in request
    self._send_request(method, url, body, headers, encode_chunked)
TypeError: _send_request() takes 5 positional arguments but 6 were given
```

Upgrading dependency for boto3 to the latest version (1.4.3) seems to have fixed it. 