### PR TITLE
updated requirements to be less restrictive

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     package_dir={'ish': 'ish'},
     packages=find_packages(),
     install_requires=[
-        'boto3==1.4.3',
-        'jmespath==0.9.0'
+        'boto3>=1.4.3',
+        'jmespath>=0.9.0'
     ]
 )


### PR DESCRIPTION
hi @grahamc I'm getting some errors such as 
```
pkg_resources.DistributionNotFound: The 'jmespath==0.9.0' distribution was not found and is required by ish
```
This library is version `0.9.2` for me and downgrading is just a temporary fix. I've added less restrictions to the setup.py, would be good to merge!